### PR TITLE
fix animation in fullwidth progress bars

### DIFF
--- a/js/wppb_animate.js
+++ b/js/wppb_animate.js
@@ -1,5 +1,5 @@
 jQuery(document).ready(function($) {
-	$(".wppb-progress.fixed > span").each(function() {
+	$(".wppb-progress.fixed > span, .wppb-progress-full > span").each(function() {
 		$(this)
 			.data("origWidth", $(this).width())
 			.width(0)


### PR DESCRIPTION
Resolves issue reported in https://wordpress.org/support/topic/error-in-animate-full/

props [@leninzapata](https://wordpress.org/support/users/leninzapata/)