### PR TITLE
add workflow for checking for vulnerabilities

### DIFF
--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -32,9 +32,7 @@ jobs:
         run: |
           echo "Setting up WordPress..."
           cd /tmp/wordpress
-          echo "debugging..."
-          ls -la
-          wp config create --dbname=wppb_tests --dbuser=root
+          wp config create --dbname=wppb_tests --dbuser=root --dbpass=root --dbhost=127.0.0.1
           wp core install --url=wordpressprogressbar.test --title=WordPress --admin_user=progressbar --admin_password=password --admin_email=noreply@dev.null
       - name: Set up plugins & vulnerability scanner
         run: |

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install WordPress Test Suite
         run: |
           echo "Installing WP Test Suite so we can use it for vulnerability scanning..."
-          bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest
+          bash bin/install-wp-tests.sh wppb_tests root root 127.0.0.1 latest
       - name: Install WP-CLI
         run: |
           echo "Installing WP-CLI..."

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -36,13 +36,8 @@ jobs:
         run: |
           echo "Setting up plugins & vulnerability scanner..."
           cd /tmp/wordpress
-          echo "GITHUB_WORKSPACE"
-          ls -la ${GITHUB_WORKSPACE}
           mkdir wp-content/plugins/progress-bar
           cp -r ${GITHUB_WORKSPACE}/* wp-content/plugins/progress-bar
-          echo "Plugins directory"
-          ls -la wp-content/plugins
-          ls -la wp-content/plugins/progress-bar
           wp plugin activate progress-bar
           wp plugin delete hello
           wp plugin delete akismet
@@ -54,6 +49,7 @@ jobs:
       - name: Scan for vulnerabilities
         run: |
           cd /tmp/wordpress
+          wp vuln plugin-status
           if [[ $(wp vuln plugin-status) =~ "No vulnerabilities reported for this version of progress-bar" ]]; then
             echo "✨ No vulnerabilities found"
             exit 0

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -1,0 +1,58 @@
+name: Scan for Vulnerabilities
+on: [push, pull_request]
+jobs:
+  vuln:
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:10.5
+    steps:
+      - uses: actions/checkout@v3
+      - name: Start MariaDB
+        run: |
+          sudo systemctl start mysql
+      - name: Install Extras
+        run: |
+          sudo apt-get update
+          sudo apt-get install subversion
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest --optimize-autoloader
+      - name: Install WordPress Test Suite
+        run: |
+          echo "Installing WP Test Suite so we can use it for vulnerability scanning..."
+          bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest
+      - name: Install WP-CLI
+        run: |
+          echo "Installing WP-CLI..."
+          cd /tmp/wordpress
+          curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+          chmod +x wp-cli.phar
+          sudo mv wp-cli.phar wp
+      - name: Set up WordPress
+        run: |
+          echo "Setting up WordPress..."
+          cd /tmp/wordpress
+          wp config create --dbname=wppb_tests --dbuser=root
+          wp core install --url=wordpressprogressbar.test --title=WordPress --admin_user=progressbar --admin_password=password --admin_email=noreply@dev.null
+      - name: Set up plugins & vulnerability scanner
+        run: |
+          echo "Setting up plugins & vulnerability scanner..."
+          cd /tmp/wordpress
+          wp plugin install --activate progress-bar
+          wp plugin delete hello
+          wp plugin delete akismet
+          rm wp-content/db.php
+          wp plugin list
+          wp package install 10up/wpcli-vulnerability-scanner:dev-trunk
+          wp config set VULN_API_PROVIDER wordfence
+          wp config set VULN_API_TOKEN ''
+      - name: Scan for vulnerabilities
+        run: |
+          cd /tmp/wordpress
+          if [[ $(wp vuln plugin-status) =~ "No vulnerabilities reported for this version of progress-bar" ]]; then
+            echo "✨ No vulnerabilities found"
+            exit 0
+          else
+            echo "❌ Vulnerabilities found"
+            exit 1
+          fi

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -36,7 +36,12 @@ jobs:
         run: |
           echo "Setting up plugins & vulnerability scanner..."
           cd /tmp/wordpress
+          echo "GITHUB_WORKSPACE"
+          ls -la ${GITHUB_WORKSPACE}
           rsync ${GITHUB_WORKSPACE} wp-content/plugins/progress-bar --exclude vendor --exclude .git --exclude .github --exclude .gitignore --exclude .gitattributes --exclude composer.json --exclude composer.lock --exclude phpunit.xml.dist --exclude .phpcs.xml.dist --exclude .phpcs.xml --exclude .phpunit.result.cache --exclude .phpunit.cache
+          echo "Plugins directory"
+          ls -la wp-content/plugins
+          ls -la wp-content/plugins/progress-bar
           wp plugin activate progress-bar
           wp plugin delete hello
           wp plugin delete akismet

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -40,7 +40,8 @@ jobs:
         run: |
           echo "Setting up plugins & vulnerability scanner..."
           cd /tmp/wordpress
-          wp plugin install --activate progress-bar
+          rsync ${GITHUB_WORKSPACE} wp-content/plugins/progress-bar --exclude vendor --exclude .git --exclude .github --exclude .gitignore --exclude .gitattributes --exclude composer.json --exclude composer.lock --exclude phpunit.xml.dist --exclude .phpcs.xml.dist --exclude .phpcs.xml --exclude .phpunit.result.cache --exclude .phpunit.cache
+          wp plugin activate progress-bar
           wp plugin delete hello
           wp plugin delete akismet
           rm wp-content/db.php

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -38,7 +38,8 @@ jobs:
           cd /tmp/wordpress
           echo "GITHUB_WORKSPACE"
           ls -la ${GITHUB_WORKSPACE}
-          rsync ${GITHUB_WORKSPACE} wp-content/plugins/progress-bar --exclude vendor --exclude .git --exclude .github --exclude .gitignore --exclude .gitattributes --exclude composer.json --exclude composer.lock --exclude phpunit.xml.dist --exclude .phpcs.xml.dist --exclude .phpcs.xml --exclude .phpunit.result.cache --exclude .phpunit.cache
+          mkdir wp-content/plugins/progress-bar
+          cp -r ${GITHUB_WORKSPACE}/* wp-content/plugins/progress-bar
           echo "Plugins directory"
           ls -la wp-content/plugins
           ls -la wp-content/plugins/progress-bar

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           echo "Setting up WordPress..."
           cd /tmp/wordpress
+          echo "debugging..."
+          ls -la
           wp config create --dbname=wppb_tests --dbuser=root
           wp core install --url=wordpressprogressbar.test --title=WordPress --admin_user=progressbar --admin_password=password --admin_email=noreply@dev.null
       - name: Set up plugins & vulnerability scanner

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -15,8 +15,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install subversion
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest --optimize-autoloader
       - name: Install WordPress Test Suite
         run: |
           echo "Installing WP Test Suite so we can use it for vulnerability scanning..."

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -27,7 +27,7 @@ jobs:
           cd /tmp/wordpress
           curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
           chmod +x wp-cli.phar
-          sudo mv wp-cli.phar wp
+          sudo mv wp-cli.phar /usr/local/bin/wp
       - name: Set up WordPress
         run: |
           echo "Setting up WordPress..."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Progress Bar
 
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/jazzsequence/progress-bar) ![Test Status](https://img.shields.io/github/actions/workflow/status/jazzsequence/progress-bar/test.yml?label=Test_Status) ![Lint Status](https://img.shields.io/github/actions/workflow/status/jazzsequence/progress-bar/lint.yml?label=Lint) ![Vulnerability Scan](https://img.shields.io/github/actions/workflow/status/jazzsequence/progress-bar/vuln.yml?label=Vulnerability_Scan)
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/jazzsequence/progress-bar) ![Test Status](https://img.shields.io/github/actions/workflow/status/jazzsequence/progress-bar/test.yml?label=Test%20Status) ![Lint Status](https://img.shields.io/github/actions/workflow/status/jazzsequence/progress-bar/lint.yml?label=Lint) ![Vulnerability Scan](https://img.shields.io/github/actions/workflow/status/jazzsequence/progress-bar/vuln.yml?label=Vulnerability%20Scan)
 
 [Donate to this plugin!](https://paypal.me/jazzsequence)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Progress Bar
 
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/jazzsequence/progress-bar) ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/jazzsequence/progress-bar/test.yml?label=tests) ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/jazzsequence/progress-bar/lint.yml?label=lint)
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/jazzsequence/progress-bar) ![Test Status](https://img.shields.io/github/actions/workflow/status/jazzsequence/progress-bar/test.yml?label=Test_Status) ![Lint Status](https://img.shields.io/github/actions/workflow/status/jazzsequence/progress-bar/lint.yml?label=Lint) ![Vulnerability Scan](https://img.shields.io/github/actions/workflow/status/jazzsequence/progress-bar/vuln.yml?label=Vulnerability_Scan)
 
 [Donate to this plugin!](https://paypal.me/jazzsequence)
 

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
             "@lint:php",
             "@lint:phpcs"
         ],
-        "test:install": "bash bin/install-wp-tests.sh wppp_tests root '' localhost latest",
-        "test:install:skipdb": "bash bin/install-wp-tests.sh wppp_tests root '' localhost latest true",
+        "test:install": "bash bin/install-wp-tests.sh wppb_tests root '' localhost latest",
+        "test:install:skipdb": "bash bin/install-wp-tests.sh wppb_tests root '' localhost latest true",
         "test": [
             "vendor/bin/phpunit -c phpunit.xml"
         ]


### PR DESCRIPTION
This adds a new GH action to check for vulnerabilities (using wordfence vulnerability scanner via 10up's `vuln` WP CLI function). Not sure how deep the free scan goes, but I've also, separately, applied for the Patchstack mVDP, so if they find anything, I'll also get notified. This doesn't need to trigger a release because this is all just stuff running in the repository.