### PR TITLE
Add tests for XSS vulnerabilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,11 @@
         ],
         "test:install": "bash bin/install-wp-tests.sh wppb_tests root '' localhost latest",
         "test:install:skipdb": "bash bin/install-wp-tests.sh wppb_tests root '' localhost latest true",
+        "test:reinstall": [
+            "rm -rf /tmp/wordpress-tests-lib",
+            "rm -rf /tmp/wordpress",
+            "@test:install:skipdb"
+        ],
         "test": [
             "vendor/bin/phpunit -c phpunit.xml"
         ]

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -55,5 +55,9 @@ class WppbTestFunctions extends TestCase {
 		// [wppb progress=50 color=ff0000 endcolor=00ff00]
 		$output = wppb_get_progress_bar( false, false, '50', false, '50%', false, '#ff0000', false, '#00ff00' );
 		$this->assertEquals( '<div class="wppb-wrapper "><div class="wppb-progress fixed"><span style="width: 50%; background: #ff0000;background: -moz-linear-gradient(top, #ff0000 0%, #00ff00 100%); background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ff0000), color-stop(100%,#00ff00)); background: -webkit-linear-gradient(top, #ff0000 0%,#00ff00 100%); background: -o-linear-gradient(top, #ff0000 0%,#00ff00 100%); background: -ms-linear-gradient(top,  0%,#00ff00 100%); background: linear-gradient(top, #ff0000 0%,#00ff00 100%); ""><span></span></span></div></div>', $output );
+
+		// Test the progress bar with an XSS vulnerability exposed.
+		$output = wppb_get_progress_bar( false, '<script>alert("XSS");</script>', '50', false, '50%', false, false, false, false );
+		$this->assertEquals( '<div class="wppb-wrapper "><div class="inside">alert("XSS");</div><div class="wppb-progress fixed"><span style="width: 50%;"><span></span></span></div></div>', $output );
 	}
 }

--- a/tests/test-main.php
+++ b/tests/test-main.php
@@ -78,6 +78,14 @@ class WppbTest extends TestCase {
 		// after
 		$output = do_shortcode('[wppb progress=50 text="Hello World" location=after]');
 		$this->assertEquals('<div class="wppb-wrapper after"><div class="after">Hello World</div><div class="wppb-progress fixed"><span style="width: 50%;"><span></span></span></div></div>', $output);
+
+		// Shortcode with XSS vulnerability exposed.
+		$output = do_shortcode('[wppb progress=50 location=inside text="<script>alert("XSS");</script>"]');
+		$this->assertEquals('<div class="wppb-wrapper inside"><div class="inside">50 %</div><div class="wppb-progress fixed"><span style="width: 50%;"><span></span></span></div></div>', $output);
+
+		// Shortcode with XSS vulnerability exposed after the progress bar.
+		$output = do_shortcode('[wppb progress=50 location=after text="<script>alert("XSS");</script>"]');
+		$this->assertEquals('<div class="wppb-wrapper after"><div class="after">50 %</div><div class="wppb-progress fixed"><span style="width: 50%;"><span></span></span></div></div>', $output);
 	}
 
 	public function test_fullwidth() {


### PR DESCRIPTION
Adds some PHPUnit coverage for XSS requests in the shortcode or function.

These should apply outward to any usage of the `wppb_get_progress_bar`, including widgets.